### PR TITLE
-> Instances: Prévoir espace de communication AVEC Schedule activity

### DIFF
--- a/jvdm_consulting_cmdb/models/res_users.py
+++ b/jvdm_consulting_cmdb/models/res_users.py
@@ -13,5 +13,5 @@ class CMDBUsers(models.Model):
     _name = 'cmdb.users'
 
     user_id = fields.Many2one(comodel_name="res.users", string="User")
-    landscp_read_access = fields.Boolean(string="Read Access", default=False)
-    landscp_write_access = fields.Boolean(string="Write Access", default=False)
+    landscp_read_access = fields.Boolean(string="Read Access", default=True)
+    landscp_write_access = fields.Boolean(string="Write Access", default=True)

--- a/jvdm_consulting_cmdb/models/system.py
+++ b/jvdm_consulting_cmdb/models/system.py
@@ -5,7 +5,7 @@ from odoo.exceptions import ValidationError
 
 class Systeme(models.Model):
     _name = "systeme"
-    _inherit = ['mail.thread']
+    _inherit = ['mail.thread', 'mail.activity.mixin']
 
     name = fields.Char(size=128)
     landscape_id = fields.Many2one('project.landscape', 'Landscape')
@@ -21,9 +21,9 @@ class Systeme(models.Model):
 
     @api.model
     def read_group(self, domain, fields, groupby, offset=0, limit=None, orderby=False, lazy=True):
-        print('domain:', domain)
-        print('fields:', fields)
-        print('groupby:', groupby)
+        # print('domain:', domain)
+        # print('fields:', fields)
+        # print('groupby:', groupby)
         res = super(Systeme, self).read_group(domain, fields, groupby, offset=offset, limit=limit, orderby=orderby,
                                             lazy=lazy)
         if groupby and groupby[0] == "landscape_id":
@@ -35,9 +35,9 @@ class Systeme(models.Model):
                             'landscape_id': (landscape.id, landscape.name),
                             'landscape_id_count': self.search_count(domain + [('landscape_id', '=', landscape.id)])
                           } for landscape in landscapes if self.search_count(domain + [('landscape_id', '=', landscape.id)]) != 0]
-                print('result:', result)
+                # print('result:', result)
                 return result
-        print('result:', res)
+        # print('result:', res)
         return res
     # @api.onchange('landscape_id')
     # def description_of_landscape(self):
@@ -49,7 +49,7 @@ class Systeme(models.Model):
 
 class Server(models.Model):
     _name = "jvdm.server"
-    _inherit = ['mail.thread']
+    _inherit = ['mail.thread', 'mail.activity.mixin']
 
     name = fields.Char(size=128)
     port = fields.Char('Port SSH', size=128)

--- a/jvdm_consulting_cmdb/views/landscape_views.xml
+++ b/jvdm_consulting_cmdb/views/landscape_views.xml
@@ -53,6 +53,7 @@
                     </sheet>
                     <div class="oe_chatter">
                         <field name="message_follower_ids" widget="mail_followers"/>
+                        <field name="activity_ids" widget="mail_activity"/>
                         <field name="message_ids" widget="mail_thread"/>
                     </div>
                 </form>

--- a/jvdm_consulting_cmdb/views/server_views.xml
+++ b/jvdm_consulting_cmdb/views/server_views.xml
@@ -29,6 +29,7 @@
                     </sheet>
                     <div class="oe_chatter">
                         <field name="message_follower_ids" widget="mail_followers"/>
+                        <field name="activity_ids" widget="mail_activity"/>
                         <field name="message_ids" widget="mail_thread"/>
                     </div>
                 </form>
@@ -45,7 +46,6 @@
                     <field name="user"/>
                     <filter string="Active" name="active" domain="[('active', '=', True)]"/>
                     <filter string="Inactive" name="inactive" domain="[('active', '=', False)]"/>
-                    <filter string="Login" name="user" context="{'group_by': 'user'}"/>
                 </search>
             </field>
         </record>

--- a/jvdm_consulting_cmdb/views/system_views.xml
+++ b/jvdm_consulting_cmdb/views/system_views.xml
@@ -36,6 +36,7 @@
                     </sheet>
                     <div class="oe_chatter">
                         <field name="message_follower_ids" widget="mail_followers"/>
+                        <field name="activity_ids" widget="mail_activity"/>
                         <field name="message_ids" widget="mail_thread"/>
                     </div>
                 </form>


### PR DESCRIPTION
-> Servers: Prévoir espace de communication AVEC Schedule activity
            Supprimer Group by Login

-> Landscapes: Prévoir espace de communication AVEC Schedule activity
               Prévoir onglet Authorized Users qui renvoie à une vue liste avec 3 colonnes : User / Read Access (booléen) / Write Access (booléen)
              Grace à ce tableau, redéfinir les droits pour les users avec le droit CDMB User
              Un user (autre que le manager) peut ajouter un autre user à aux users d'un landscape particulier? Négatif, seul le manager peut ajouter des membres